### PR TITLE
Pass through event listeners

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,11 @@ var propTypes = {
   multiLine: _propTypes2.default.bool,
   onChange: _propTypes2.default.func,
   sanitise: _propTypes2.default.bool,
-  tagName: _propTypes2.default.string
+  tagName: _propTypes2.default.string,
+  innerRef: _propTypes2.default.func,
+  onBlur: _propTypes2.default.func,
+  onKeyDown: _propTypes2.default.func,
+  onPaste: _propTypes2.default.func
 };
 
 var defaultProps = {
@@ -44,7 +48,11 @@ var defaultProps = {
   maxLength: Infinity,
   multiLine: false,
   sanitise: true,
-  tagName: 'div'
+  tagName: 'div',
+  innerRef: function innerRef() {},
+  onBlur: function onBlur() {},
+  onKeyDown: function onKeyDown() {},
+  onPaste: function onPaste() {}
 };
 
 var ContentEditable = function (_Component) {
@@ -75,6 +83,8 @@ var ContentEditable = function (_Component) {
       ev.preventDefault();
       var text = ev.clipboardData.getData('text').substr(0, maxLength);
       document.execCommand('insertText', false, text);
+
+      _this.props.onPaste(ev);
     };
 
     _this._onBlur = function (ev) {
@@ -88,6 +98,8 @@ var ContentEditable = function (_Component) {
         _this.forceUpdate();
         _this.props.onChange(ev, value);
       });
+
+      _this.props.onBlur(ev);
     };
 
     _this._onKeyDown = function (ev) {
@@ -107,6 +119,8 @@ var ContentEditable = function (_Component) {
       if (maxLength && !ev.metaKey && ev.which !== 8 && value.replace(/\s\s/g, ' ').length >= maxLength) {
         ev.preventDefault();
       }
+
+      _this.props.onKeyDown(ev);
     };
 
     _this.state = {
@@ -170,7 +184,8 @@ var ContentEditable = function (_Component) {
 
       return _react2.default.createElement(Element, _extends({}, (0, _lodash.omit)(props, Object.keys(propTypes)), {
         ref: function ref(c) {
-          return _this2._element = c;
+          _this2._element = c;
+          props.innerRef(c);
         },
         style: _extends({ whiteSpace: 'pre-wrap' }, props.style),
         contentEditable: editable,

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -10,6 +10,10 @@ const propTypes = {
   onChange: PropTypes.func,
   sanitise: PropTypes.bool,
   tagName: PropTypes.string,
+  innerRef: PropTypes.func,
+  onBlur: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onPaste: PropTypes.func,
 };
 
 const defaultProps = {
@@ -19,6 +23,10 @@ const defaultProps = {
   multiLine: false,
   sanitise: true,
   tagName: 'div',
+  innerRef: () => {},
+  onBlur: () => {},
+  onKeyDown: () => {},
+  onPaste: () => {},
 };
 
 class ContentEditable extends Component {
@@ -88,6 +96,8 @@ class ContentEditable extends Component {
     ev.preventDefault();
     const text = ev.clipboardData.getData('text').substr(0, maxLength);
     document.execCommand('insertText', false, text);
+
+    this.props.onPaste(ev);
   }
 
   _onBlur = (ev) => {
@@ -100,6 +110,8 @@ class ContentEditable extends Component {
       this.forceUpdate();
       this.props.onChange(ev, value);
     });
+
+    this.props.onBlur(ev);
   }
 
   _onKeyDown = (ev) => {
@@ -116,6 +128,8 @@ class ContentEditable extends Component {
     if (maxLength && !ev.metaKey && ev.which !== 8 && value.replace(/\s\s/g, ' ').length >= maxLength) {
       ev.preventDefault();
     }
+
+    this.props.onKeyDown(ev);
   }
 
   render() {
@@ -124,7 +138,10 @@ class ContentEditable extends Component {
     return (
       <Element
         {...omit(props, Object.keys(propTypes))}
-        ref={(c) => this._element = c}
+        ref={(c) => {
+          this._element = c;
+          props.innerRef(c);
+        }}
         style={{ whiteSpace: 'pre-wrap', ...props.style }}
         contentEditable={editable}
         dangerouslySetInnerHTML={{ __html: this.state.value }}


### PR DESCRIPTION
Also allows accessing the inner ref, so I can `.focus()` the element in `componentDidMount()`