### PR TITLE
styled-component support

### DIFF
--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -10,7 +10,7 @@ const propTypes = {
   onChange: PropTypes.func,
   sanitise: PropTypes.bool,
   /** The element to make contenteditable. Takes an element string ('div', 'span', 'h1') or a styled component */
-  tagName: PropTypes.string,
+  tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   innerRef: PropTypes.func,
   onBlur: PropTypes.func,
   onKeyDown: PropTypes.func,

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -9,11 +9,14 @@ const propTypes = {
   multiLine: PropTypes.bool,
   onChange: PropTypes.func,
   sanitise: PropTypes.bool,
+  /** The element to make contenteditable. Takes an element string ('div', 'span', 'h1') or a styled component */
   tagName: PropTypes.string,
   innerRef: PropTypes.func,
   onBlur: PropTypes.func,
   onKeyDown: PropTypes.func,
   onPaste: PropTypes.func,
+  /** tagName is a styled component (uses innerRef instead of ref) */
+  styled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -27,6 +30,7 @@ const defaultProps = {
   onBlur: () => {},
   onKeyDown: () => {},
   onPaste: () => {},
+  styled: false,
 };
 
 class ContentEditable extends Component {
@@ -133,15 +137,24 @@ class ContentEditable extends Component {
   }
 
   render() {
-    const { tagName: Element, content, editable, ...props } = this.props;
+    const { tagName: Element, content, editable, styled, ...props } = this.props;
 
     return (
       <Element
         {...omit(props, Object.keys(propTypes))}
-        ref={(c) => {
-          this._element = c;
-          props.innerRef(c);
-        }}
+        {...(styled
+            ? {
+                innerRef: (c) => {
+                  this._element = c;
+                  props.innerRef(c);
+                },
+              }
+            : {
+                ref: (c) => {
+                  this._element = c;
+                  props.innerRef(c);
+                },
+        })}
         style={{ whiteSpace: 'pre-wrap', ...props.style }}
         contentEditable={editable}
         dangerouslySetInnerHTML={{ __html: this.state.value }}


### PR DESCRIPTION
Adds styled component support to react-sane-contenteditable.

I did the change manually in the `lib/index.js` file and everything worked normally once I switched `ref` to `innerRef`.

Added the styled tag to switch between `ref` and `innerRef`, relatively small change to API that adds a lot of use.