### PR TITLE
Expose the current value in onKeyDown handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,9 @@ var ContentEditable = function (_Component) {
         ev.preventDefault();
       }
 
-      _this.props.onKeyDown(ev);
+      setTimeout(function () {
+        _this.props.onKeyDown(ev, _this._element.innerText);
+      }, 0);
     };
 
     _this.state = {

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -129,7 +129,9 @@ class ContentEditable extends Component {
       ev.preventDefault();
     }
 
-    this.props.onKeyDown(ev);
+    setTimeout(() => {
+      this.props.onKeyDown(ev, this._element.innerText);
+    }, 0);
   }
 
   render() {


### PR DESCRIPTION
I noticed when using this component that content editable elements with `onKeyDown` handlers show some unexpected behavior when reading the `innerText` of the element. At the time the event is fired, the `innerText` has not been set into the DOM, so the value will be the previous value rather than the value that results from new changes: [see this JSBin](http://output.jsbin.com/zinakoc) to test this.

These changes pass a new, second argument to `this.props.onKeyDown` with the up-to-date value by requesting the `innerText` in an event after the browser has rendered the user's changes (using `setTimeout`). 