### PR TITLE
Fix issues #6 and #14 using onKeyUp in conjunction with onKeyDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,7 @@ typings/
 # dotenv environment variables file
 .env
 
+# IDE specific
+.idea
+
 example/index.min.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,16 +102,24 @@ var ContentEditable = function (_Component) {
       if (!multiLine && ev.keyCode === 13) {
         ev.preventDefault();
         ev.currentTarget.blur();
+        // Call onKeyUp directly as ev.preventDefault() means that it will not be called
+        _this._onKeyUp(ev);
       }
 
       // Ensure we don't exceed `maxLength` (keycode 8 === backspace)
       if (maxLength && !ev.metaKey && ev.which !== 8 && value.replace(/\s\s/g, " ").length >= maxLength) {
         ev.preventDefault();
+        // Call onKeyUp directly as ev.preventDefault() means that it will not be called
+        _this._onKeyUp(ev);
       }
+    };
 
-      setTimeout(function () {
-        _this.props.onKeyDown(ev, _this._element.innerText);
-      }, 0);
+    _this._onKeyUp = function (ev) {
+      // Call prop.onKeyDown callback from the onKeyUp event to mitigate both of these issues:
+      // Access to Synthetic event: https://github.com/ashleyw/react-sane-contenteditable/issues/14
+      // Current value onKeyDown: https://github.com/ashleyw/react-sane-contenteditable/pull/6
+      // this._onKeyDown can't be moved in it's entirety to onKeyUp as we lose the opportunity to preventDefault
+      _this.props.onKeyDown(ev, _this._element.innerText);
     };
 
     _this.state = {
@@ -191,6 +199,7 @@ var ContentEditable = function (_Component) {
         onBlur: this._onBlur,
         onInput: this._onChange,
         onKeyDown: this._onKeyDown,
+        onKeyUp: this._onKeyUp,
         onPaste: this._onPaste
       }));
     }

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -125,6 +125,8 @@ class ContentEditable extends Component {
     if (!multiLine && ev.keyCode === 13) {
       ev.preventDefault();
       ev.currentTarget.blur();
+      // Call onKeyUp directly as ev.preventDefault() means that it will not be called
+      this._onKeyUp(ev);
     }
 
     // Ensure we don't exceed `maxLength` (keycode 8 === backspace)
@@ -135,11 +137,17 @@ class ContentEditable extends Component {
       value.replace(/\s\s/g, " ").length >= maxLength
     ) {
       ev.preventDefault();
+      // Call onKeyUp directly as ev.preventDefault() means that it will not be called
+      this._onKeyUp(ev);
     }
+  };
 
-    setTimeout(() => {
-      this.props.onKeyDown(ev, this._element.innerText);
-    }, 0);
+  _onKeyUp = ev => {
+    // Call prop.onKeyDown callback from the onKeyUp event to mitigate both of these issues:
+    // Access to Synthetic event: https://github.com/ashleyw/react-sane-contenteditable/issues/14
+    // Current value onKeyDown: https://github.com/ashleyw/react-sane-contenteditable/pull/6
+    // this._onKeyDown can't be moved in it's entirety to onKeyUp as we lose the opportunity to preventDefault
+    this.props.onKeyDown(ev, this._element.innerText)
   };
 
   render() {
@@ -174,6 +182,7 @@ class ContentEditable extends Component {
         onBlur={this._onBlur}
         onInput={this._onChange}
         onKeyDown={this._onKeyDown}
+        onKeyUp={this._onKeyUp}
         onPaste={this._onPaste}
       />
     );


### PR DESCRIPTION
Fixes #14 

### What's new/changed?

1. Updated `.gitignore` to exclude IDEA specific files
2. Use `onKeyUp` instead of `setTimeout` to call `this.props.onKeyDown`

Whilst I appreciate that #2 is a bit weird, I figured it would be better than a breaking change to the API to this component. The issues are as I see it:

1. The element's `innerText` has not yet been updated in the DOM when the `onKeyDown` event is called, which is why it requires a `setTimeout` to push the getter onto the stack, thus making it async and able to be executed after the next scheduled event `onKeyUp`.  In my mind this is a bit of kludge and generally a setTimeout to fix an issue has a bit of code smell to it.

2. React's Event pooling means that event objects are re-cycled, AFAICT once an event is accessed asynchronously there is no guarantee that the values have not been nullified: 
> The SyntheticEvent is pooled. This means that the SyntheticEvent object will be reused and all properties will be nullified after the event callback has been invoked. This is for performance reasons. As such, you cannot access the event in an asynchronous way.

3. [The `onKeyUp` approach](http://jsbin.com/haxusex/edit?html,js,output) appears to be the most robust way of getting the `innerText`, however in certain circumstances such as when the Enter key is pressed & `multiLine = false`, and also when `maxLength` is reached we want to be able to `preventDefault` on the `keyDown` event, however we lose the `keyUp` event. So I'm having to call `_this._onKeyUp` explicitly in those instances.

Assuming that this fix is appropriate as a temporary measure, it would be appropriate to schedule a major version update that deals with this change. The change could even support backward compatibility with a deprecation warning for any users passing `onKeyDown` in the props.