### PR TITLE
Set Caret Position

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -19,6 +19,7 @@ class App extends Component {
     return (
       <div className="App">
         <ContentEditable
+          focus
           tagName="h1"
           className="my-class"
           content={this.state.title}
@@ -26,6 +27,7 @@ class App extends Component {
           maxLength={140}
           multiLine={true}
           onChange={this.handleChange}
+          caretPosition="end"
         />
 
         <b>Value:</b>

--- a/jest.config.js
+++ b/jest.config.js
@@ -124,7 +124,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  // testEnvironment: "jest-environment-jsdom",
+  testEnvironment: "jest-environment-jsdom",
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,11 @@ import { omit, isEqual, pick, without } from "lodash";
 var propTypes = {
   content: PropTypes.string,
   editable: PropTypes.bool,
+  focus: PropTypes.bool,
   maxLength: PropTypes.number,
   multiLine: PropTypes.bool,
   sanitise: PropTypes.bool,
+  caretPosition: PropTypes.oneOf(['start', 'end']),
   tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   // The element to make contenteditable. Takes an element string ('div', 'span', 'h1') or a styled component
   innerRef: PropTypes.func,
@@ -48,9 +50,11 @@ var propTypes = {
 var defaultProps = {
   content: "",
   editable: true,
+  focus: false,
   maxLength: Infinity,
   multiLine: false,
   sanitise: true,
+  caretPosition: null,
   tagName: "div",
   innerRef: function innerRef() {},
   onBlur: function onBlur() {},
@@ -71,6 +75,26 @@ function (_Component) {
     _classCallCheck(this, ContentEditable);
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(ContentEditable).call(this, props));
+
+    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "setFocus", function () {
+      if (_this.props.focus && _this._element) {
+        _this._element.focus();
+      }
+    });
+
+    _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "setCaret", function () {
+      var caretPosition = _this.props.caretPosition;
+
+      if (caretPosition && _this._element) {
+        var offset = caretPosition === 'end' ? 1 : 0;
+        var range = document.createRange();
+        var selection = window.getSelection();
+        range.setStart(_this._element, offset);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    });
 
     _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "_onChange", function (ev) {
       var sanitise = _this.props.sanitise;
@@ -147,6 +171,12 @@ function (_Component) {
   }
 
   _createClass(ContentEditable, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.setFocus();
+      this.setCaret();
+    }
+  }, {
     key: "componentWillReceiveProps",
     value: function componentWillReceiveProps(nextProps) {
       if (nextProps.content !== this.sanitiseValue(this.state.value)) {
@@ -160,6 +190,12 @@ function (_Component) {
     value: function shouldComponentUpdate(nextProps) {
       var propKeys = without(Object.keys(nextProps), "content");
       return !isEqual(pick(nextProps, propKeys), pick(this.props, propKeys));
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate() {
+      this.setFocus();
+      this.setCaret();
     }
   }, {
     key: "sanitiseValue",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.10.0",
     "jest": "^23.4.2",
+    "jsdom": "^11.12.0",
     "react-dom": "^16.3.2",
     "rollup": "^0.58.2",
     "rollup-plugin-babel": "^4.0.0-beta.8",
@@ -46,7 +47,8 @@
     "rollup-plugin-jsx": "^1.0.3",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
-    "rollup-plugin-serve": "^0.4.2"
+    "rollup-plugin-serve": "^0.4.2",
+    "styled-components": "^3.4.2"
   },
   "scripts": {
     "build": "./node_modules/.bin/babel src/react-sane-contenteditable.js --out-file lib/index.js",

--- a/src/__tests__/react-sane-contenteditable.test.js
+++ b/src/__tests__/react-sane-contenteditable.test.js
@@ -1,9 +1,30 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { JSDOM } from 'jsdom';
+import styled from 'styled-components';
+
+// SuT
 import ContentEditable from '../react-sane-contenteditable';
+
+// jsDOM
+const doc = new JSDOM('<!doctype html><html><body></body></html>');
+global.document = doc;
+global.window = doc.defaultView;
+global.window.getSelection = jest.fn(() => ({
+  addRange: jest.fn(),
+  removeAllRanges: jest.fn(),
+}));
+
+global.document.createRange = jest.fn(() => ({
+  collapse: jest.fn(),
+  setStart: jest.fn(),
+}));
 
 // Helpers
 const focusThenBlur = (wrapper, element = 'div') => wrapper.find(element).simulate('focus').simulate('blur');
+
+// Styled components
+const Wrapper = styled.div``;
 
 describe('Default behaviour', () => {
   it('renders a div by default', () => {
@@ -16,7 +37,7 @@ describe('Default behaviour', () => {
     expect(wrapper.key()).toEqual(Date());
   });
 
-  it('sets contenteditable', () => {
+  it('sets contentEditable', () => {
     const wrapper = shallow(<ContentEditable />);
     expect(wrapper.prop('contentEditable')).toBe(true);
   });
@@ -63,10 +84,46 @@ describe('Handles props', () => {
     expect(wrapper.prop('contentEditable')).toBe(false);
   });
 
-  // @todo: I think Enzyme converts props.ref to props.innerRef when props.styled={false}
   it('props.styled={true} sets innerRef handler', () => {
-    const wrapper = mount(<ContentEditable />);
+    const wrapper = mount(<ContentEditable styled tagName={Wrapper} />);
     expect(wrapper.prop('innerRef')).toEqual(expect.any(Function));
+  });
+
+  it('props.content change calls setState and forceUpdate', () => {
+    const wrapper = mount(<ContentEditable content="" />);
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'setState');
+    jest.spyOn(instance, 'forceUpdate');
+
+    wrapper.setProps({ content: 'foo' });
+
+    expect(instance.setState).toHaveBeenCalled();
+    expect(instance.forceUpdate).toHaveBeenCalled();
+  });
+
+  it('props.focus sets focus on update', () => {
+    const wrapper = mount(<ContentEditable />);
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'setFocus');
+
+    wrapper.setProps({ focus: true });
+
+    expect(instance.setFocus).toHaveBeenCalled();
+  });
+
+  it('props.caretPosition sets selection on mount', () => {
+    mount(<ContentEditable caretPosition="start" />);
+    expect(global.window.getSelection).toHaveBeenCalled();
+  });
+
+  it('props.caretPosition sets selection on update', () => {
+    const wrapper = mount(<ContentEditable />);
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'setCaret');
+
+    wrapper.setProps({ caretPosition: 'end' });
+
+    expect(instance.setCaret).toHaveBeenCalled();
   });
 
   it('shouldComponentUpdate returns false when props are the same', () => {
@@ -263,7 +320,6 @@ describe('Calls handlers', () => {
   it('props.innerRef called', () => {
     const mockHandler = jest.fn();
     const wrapper = mount(<ContentEditable innerRef={mockHandler} />);
-    wrapper.render();
     expect(mockHandler).toHaveBeenCalled();
   });
 

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -5,9 +5,11 @@ import { omit, isEqual, pick, without } from "lodash";
 const propTypes = {
   content: PropTypes.string,
   editable: PropTypes.bool,
+  focus: PropTypes.bool,
   maxLength: PropTypes.number,
   multiLine: PropTypes.bool,
   sanitise: PropTypes.bool,
+  caretPosition: PropTypes.oneOf(['start', 'end']),
   tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]), // The element to make contenteditable. Takes an element string ('div', 'span', 'h1') or a styled component
   innerRef: PropTypes.func,
   onBlur: PropTypes.func,
@@ -20,9 +22,11 @@ const propTypes = {
 const defaultProps = {
   content: "",
   editable: true,
+  focus: false,
   maxLength: Infinity,
   multiLine: false,
   sanitise: true,
+  caretPosition: null,
   tagName: "div",
   innerRef: () => {},
   onBlur: () => {},
@@ -41,6 +45,11 @@ class ContentEditable extends Component {
     };
   }
 
+  componentDidMount() {
+    this.setFocus();
+    this.setCaret();
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.content !== this.sanitiseValue(this.state.value)) {
       this.setState({ value: nextProps.content }, this.forceUpdate);
@@ -51,6 +60,32 @@ class ContentEditable extends Component {
     const propKeys = without(Object.keys(nextProps), "content");
     return !isEqual(pick(nextProps, propKeys), pick(this.props, propKeys));
   }
+
+  componentDidUpdate() {
+    this.setFocus();
+    this.setCaret();
+  }
+
+  setFocus = () => {
+    if (this.props.focus && this._element) {
+      this._element.focus();
+    }
+  };
+
+  setCaret = () => {
+    const { caretPosition } = this.props;
+
+    if (caretPosition && this._element) {
+      const offset = caretPosition === 'end' ? 1 : 0;
+      const range = document.createRange();
+      const selection = window.getSelection();
+      range.setStart(this._element, offset);
+      range.collapse(true);
+
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  };
 
   sanitiseValue(val) {
     const { maxLength, multiLine, sanitise } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,6 +1118,10 @@ base62@^1.1.0:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.8.tgz#1264cb0fb848d875792877479dbe8bae6bae3428"
 
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1200,6 +1204,13 @@ bser@^2.0.0:
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+buffer@^5.0.3:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1476,6 +1487,10 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -1484,6 +1499,14 @@ css-select@~1.2.0:
     css-what "2.1"
     domutils "1.5.1"
     nth-check "~1.0.1"
+
+css-to-react-native@^2.0.3:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.1.tgz#7f3f4c95de65501b8720c87bf0caf1f39073b88e"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -2124,7 +2147,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
+fbjs@^0.8.16, fbjs@^0.8.5:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -2445,6 +2468,10 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2486,6 +2513,10 @@ iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5, ico
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -3201,7 +3232,7 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.5.1:
+jsdom@^11.12.0, jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   dependencies:
@@ -4002,6 +4033,10 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4042,7 +4077,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -4116,7 +4151,7 @@ react-dom@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-is@^16.4.2:
+react-is@^16.3.1, react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
@@ -4788,11 +4823,33 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+styled-components@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.2.tgz#8f518419932327e47fe9144824e3184b3e2da95d"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.5.4"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^3.2.3"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
Fixes #21 

### What's new/changed?

1. Add focus prop which focusses the field on Mount/Update
2. Add caretPosition prop: accepts 'start' or 'end' to set the caret position on Mount/Update
3. Add tests
4. Add test missing coverage, including StyledComponents

_N.B. Line 98 is covered by [this test](https://github.com/ashleyw/react-sane-contenteditable/blob/4114fba5172ad825ea48feac27dd773c3fc314bf/src/__tests__/react-sane-contenteditable.test.js#L151-L159) but annoyingly the test coverage doesn't seem to think it's covered.

![screen shot 2018-08-14 at 09 56 57](https://user-images.githubusercontent.com/1615460/44082188-7033cb5e-9fa8-11e8-9be1-b6acb17afb12.png)
