### PR TITLE
Fix issue with forceUpdate in componentWillReceiveProps

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -15,6 +15,10 @@ class App extends Component {
     this.setState({ title: value });
   };
 
+  handleKeyDown = (ev, value) => {
+    this.setState({ title: value });
+  };
+
   render() {
     return (
       <div className="App">
@@ -26,6 +30,7 @@ class App extends Component {
           maxLength={140}
           multiLine={true}
           onChange={this.handleChange}
+          onKeyDown={this.handleKeyDown}
         />
 
         <b>Value:</b>
@@ -33,7 +38,7 @@ class App extends Component {
           style={{
             fontSize: 14,
             fontFamily:
-              "'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace"
+              '\'Courier New\', Courier, \'Lucida Sans Typewriter\', \'Lucida Typewriter\', monospace'
           }}
         >
           {this.state.title}

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -43,7 +43,7 @@ class ContentEditable extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.content !== this.sanitiseValue(this.state.value)) {
-      this.setState({ value: nextProps.content }, this.forceUpdate);
+      this.setState({ value: nextProps.content });
     }
   }
 


### PR DESCRIPTION
Fixes #16 by removing `forceUpdate` from `componentWillUpdate`. It also adds a state mutating `onKeyDown` handler in the demo.

_N.B. It doesn't however address the issue of using `componentWillUpdate` or indeed the use of `setState` within that lifecycle method. I plan to remove those at a later date._