### PR TITLE
Move dependencies to peerDependencies & devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
     "Jess Telford"
   ],
   "license": "MIT",
-  "dependencies": {
-    "lodash": "^4.17.10",
-    "prop-types": "^15.6.0",
-    "react": "^16.0.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.0.0-rc.1",
     "@babel/core": "^7.0.0-rc.1",
@@ -34,7 +29,10 @@
     "husky": "1.0.0-rc.13",
     "jest": "^23.4.2",
     "jsdom": "^11.12.0",
+    "lodash": "^4.17.10",
     "prettier": "1.14.2",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
     "react-dom": "^16.3.2",
     "rollup": "^0.58.2",
     "rollup-plugin-babel": "^4.0.0-beta.8",
@@ -44,6 +42,11 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-serve": "^0.4.2",
     "styled-components": "^3.4.2"
+  },
+  "peerDependencies": {
+    "lodash": "^4.17.10",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2"
   },
   "scripts": {
     "build": "./node_modules/.bin/babel src/react-sane-contenteditable.js --out-file lib/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,7 +3726,7 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.0"
     react-is "^16.4.2"
 
-react@^16.0.0:
+react@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:


### PR DESCRIPTION
Fixes #36 

Unfortunately it is also necessary to add the `peerDependencies` to `devDependencies` as the [yarn maintainers are rather opinionated about how this should be managed for libraries](https://github.com/yarnpkg/yarn/issues/1503).

The issue is that we need to use peerDependencies for when the lib is consumed by other projects, yet we also need to install those peerDependencies for local development, but ideally they wouldn't change `package.json`. This doesn't seem to be possible with yarn, so the workaround mentioned in the issue linked to above is to install the deps in both sections - the downside of this approach is that the devDependencies need to be kept in sync with the peerDependencies as time goes on...

There does seem to be [a glimmer of hope](https://github.com/yarnpkg/yarn/issues/1503#issuecomment-373948767) right at the end of the thread but it's been 5 months since that discussion ended and I can't find the PR or any similar functionality in yarn 👎 I'll keep an eye out for it in the future with the hope of being able to automatically manage the peerDeps as devDeps.