### PR TITLE
Move prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.1.2"
+    "@babel/runtime": "^7.1.2",
+    "prop-types": "^15.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-rc.1",
@@ -37,7 +38,6 @@
     "jest": "^23.4.2",
     "jsdom": "^11.12.0",
     "prettier": "1.14.2",
-    "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-dom": "^16.3.2",
     "rimraf": "^2.6.2",
@@ -54,7 +54,6 @@
     "styled-components": "^3.4.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.2",
     "react": "^16.4.2"
   },
   "scripts": {


### PR DESCRIPTION
The prop-types package recommends for libraries to install prop-types as a direct dependency rather than a peer dependency. This change simplifies consumption of react-sane-contenteditable for projects who would otherwise not need to install prop-types. Package managers will still be able to dedupe compatible versions of prop-types so there will be no bundle size increase in those cases. 

https://github.com/facebook/prop-types#how-to-depend-on-this-package