### PR TITLE
Use UNSAFE_componentWillReceiveProps alias to avoid DEV-mode warning.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 14282,
-    "minified": 6125,
-    "gzipped": 2289
+    "bundled": 14296,
+    "minified": 6132,
+    "gzipped": 2299
   },
   "dist/index.umd.min.js": {
-    "bundled": 14282,
-    "minified": 6125,
-    "gzipped": 2289
+    "bundled": 14296,
+    "minified": 6132,
+    "gzipped": 2299
   },
   "dist/index.esm.js": {
-    "bundled": 13075,
-    "minified": 7096,
-    "gzipped": 2333,
+    "bundled": 13089,
+    "minified": 7103,
+    "gzipped": 2345,
     "treeshaked": {
       "rollup": {
-        "code": 5809,
+        "code": 5816,
         "import_statements": 63
       },
       "webpack": {
-        "code": 6899
+        "code": 6906
       }
     }
   }

--- a/lib/cjs/react-sane-contenteditable.js
+++ b/lib/cjs/react-sane-contenteditable.js
@@ -219,8 +219,8 @@ function (_Component) {
       this.setCaret();
     }
   }, {
-    key: "componentWillReceiveProps",
-    value: function componentWillReceiveProps(nextProps) {
+    key: "UNSAFE_componentWillReceiveProps",
+    value: function UNSAFE_componentWillReceiveProps(nextProps) {
       if (nextProps.content !== this.sanitiseValue(this.state.value)) {
         this.setState({
           value: nextProps.content

--- a/lib/esm/react-sane-contenteditable.js
+++ b/lib/esm/react-sane-contenteditable.js
@@ -188,8 +188,8 @@ function (_Component) {
       this.setCaret();
     }
   }, {
-    key: "componentWillReceiveProps",
-    value: function componentWillReceiveProps(nextProps) {
+    key: "UNSAFE_componentWillReceiveProps",
+    value: function UNSAFE_componentWillReceiveProps(nextProps) {
       if (nextProps.content !== this.sanitiseValue(this.state.value)) {
         this.setState({
           value: nextProps.content

--- a/src/react-sane-contenteditable.js
+++ b/src/react-sane-contenteditable.js
@@ -4,10 +4,18 @@ import PropTypes from 'prop-types';
 const reduceTargetKeys = (target, keys, predicate) => Object.keys(target).reduce(predicate, {});
 
 const omit = (target = {}, keys = []) =>
-  reduceTargetKeys(target, keys, (acc, key) => keys.some(omitKey => omitKey === key) ? acc : { ...acc, [key]: target[key] });
+  reduceTargetKeys(
+    target,
+    keys,
+    (acc, key) => (keys.some(omitKey => omitKey === key) ? acc : { ...acc, [key]: target[key] }),
+  );
 
 const pick = (target = {}, keys = []) =>
-  reduceTargetKeys(target, keys, (acc, key) => keys.some(pickKey => pickKey === key) ? { ...acc, [key]: target[key] } : acc);
+  reduceTargetKeys(
+    target,
+    keys,
+    (acc, key) => (keys.some(pickKey => pickKey === key) ? { ...acc, [key]: target[key] } : acc),
+  );
 
 const isEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 
@@ -59,7 +67,7 @@ class ContentEditable extends Component {
     this.setCaret();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.content !== this.sanitiseValue(this.state.value)) {
       this.setState({ value: nextProps.content });
     }
@@ -105,7 +113,9 @@ class ContentEditable extends Component {
     }
 
     // replace encoded spaces
-    let value = val.replace(/&nbsp;/, ' ').replace(/[\u00a0\u2000-\u200b\u2028-\u2029\u202e-\u202f\u3000]/g, ' ');
+    let value = val
+      .replace(/&nbsp;/, ' ')
+      .replace(/[\u00a0\u2000-\u200b\u2028-\u2029\u202e-\u202f\u3000]/g, ' ');
 
     if (multiLine) {
       // replace any 2+ character whitespace (other than new lines) with a single space
@@ -172,7 +182,12 @@ class ContentEditable extends Component {
     }
 
     // Ensure we don't exceed `maxLength` (keycode 8 === backspace)
-    if (maxLength && !ev.metaKey && ev.which !== 8 && value.replace(/\s\s/g, ' ').length >= maxLength) {
+    if (
+      maxLength &&
+      !ev.metaKey &&
+      ev.which !== 8 &&
+      value.replace(/\s\s/g, ' ').length >= maxLength
+    ) {
       ev.preventDefault();
       // Call onKeyUp directly as ev.preventDefault() means that it will not be called
       this._onKeyUp(ev);


### PR DESCRIPTION
Fixes #56.

Update componentWillReceiveProps to UNSAFE_componentWillReceiveProps in order to avoid a React DEV-mode warning. See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path for more details.

This alias was introduced in 16.3, which is compatible with react-sane-contenteditable's peer dependency on react ^16.4.2.

Some unrelated formatting changed due to prettier.

This appears to be made obsolete by #52, but it would be great it this could be merged in and released as a patch now since it's such a small change.